### PR TITLE
Update GlobalBackendcentreonbroker.php

### DIFF
--- a/GlobalBackendcentreonbroker.php
+++ b/GlobalBackendcentreonbroker.php
@@ -553,7 +553,6 @@ class GlobalBackendcentreonbroker implements GlobalBackendInterface {
         }
         $queryCount = 'SELECT
             hg.name,
-            hg.alias,
             SUM(IF(h.checked=0,1,0)) AS unchecked,
             SUM(IF(('.$stateAttr.'=0 AND h.checked!=0 AND h.scheduled_downtime_depth=0),1,0)) AS up,
             SUM(IF(('.$stateAttr.'=0 AND h.checked!=0 AND h.scheduled_downtime_depth!=0),1,0)) AS up_downtime,
@@ -586,7 +585,7 @@ class GlobalBackendcentreonbroker implements GlobalBackendInterface {
         $counts = array();
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $counts[$row['name']] = array(
-                'details' => array(ALIAS => $row['alias']),
+                'details' => array('name' => $row['name']),
                 'counts' => array(
                     UNCHECKED => array(
                         'normal'    => intval($row['unchecked']),
@@ -619,7 +618,6 @@ class GlobalBackendcentreonbroker implements GlobalBackendInterface {
         }
         $queryCount = 'SELECT
             hg.name,
-            hg.alias,
             SUM(IF(s.checked=0,1,0)) AS pending,
             SUM(IF(('.$stateAttr.'=0 AND s.checked!=0 AND s.scheduled_downtime_depth=0),1,0)) AS ok,
             SUM(IF(('.$stateAttr.'=0 AND s.checked!=0 AND s.scheduled_downtime_depth!=0),1,0)) AS ok_downtime,
@@ -676,7 +674,6 @@ class GlobalBackendcentreonbroker implements GlobalBackendInterface {
         }
         $queryCount = 'SELECT
             sg.name,
-            sg.alias,
             SUM(IF(s.checked=0,1,0)) AS pending,
             SUM(IF(('.$stateAttr.'=0 AND s.checked!=0 AND s.scheduled_downtime_depth=0),1,0)) AS ok,
             SUM(IF(('.$stateAttr.'=0 AND s.checked!=0 AND s.scheduled_downtime_depth!=0),1,0)) AS ok_downtime,
@@ -705,7 +702,7 @@ class GlobalBackendcentreonbroker implements GlobalBackendInterface {
         $counts = array();
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $counts[$row['name']] = array(
-                'details' => array(ALIAS => $row['alias']),
+                'details' => array('name' => $row['name']),
                 'counts' => array(
                     PENDING => array(
                         'normal'   => intval($row['pending']),
@@ -884,7 +881,7 @@ class GlobalBackendcentreonbroker implements GlobalBackendInterface {
      * @throws BackendConnectionProblem
      */
     private function connectToDb() {
-        if (false === extension_loaded('mysql')) {
+        if (false === extension_loaded('mysqli')) {
             throw new BackendConnectionProblem(l('mysqlNotSupported', array('BACKENDID', $this->_backendId)));
         }
         $fullhost = 'host=' . $this->_dbhost;


### PR DESCRIPTION
For version 1.9 of nagvis and version 19.04, there are fields that no longer exist in the database that cause nagvis to crash. All that is in aliases, hg_alias or sg_alias are no longer in base and cause the software to crash.
Moreover extension_loaded is mysqli now.